### PR TITLE
Remove PhpStorm Comments

### DIFF
--- a/src/Commands/MakeBaseRepository.php
+++ b/src/Commands/MakeBaseRepository.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: a.mir
- * Date: 23/12/2018
- * Time: 09:36 AM
- */
-
 namespace amin3520\Anar\Commands;
 
 

--- a/src/Commands/MakeBaseRepositoryImp.php
+++ b/src/Commands/MakeBaseRepositoryImp.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: a.mir
- * Date: 23/12/2018
- * Time: 09:37 AM
- */
-
 namespace amin3520\Anar\Commands;
 
 

--- a/src/Commands/MakeRepositoryImpCommand.php
+++ b/src/Commands/MakeRepositoryImpCommand.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: a.mir
- * Date: 10/10/2018
- * Time: 02:22 PM
- */
-
 namespace amin3520\Anar\Commands;
 
 

--- a/src/Commands/MakeRepositoryProvider.php
+++ b/src/Commands/MakeRepositoryProvider.php
@@ -1,11 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: a.mir
- * Date: 25/12/2018
- * Time: 01:00 PM
- */
-
 namespace amin3520\Anar\Commands;
 
 

--- a/src/Commands/stubs/BaseRepository.stub
+++ b/src/Commands/stubs/BaseRepository.stub
@@ -1,11 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: amin
- * Date: 07/09/2018
- * Time: 05:39 PM
- */
-
 namespace App\Repositories;
 
 

--- a/src/Commands/stubs/BaseRepositoryImp.stub
+++ b/src/Commands/stubs/BaseRepositoryImp.stub
@@ -1,11 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: amin
- * Date: 07/09/2018
- * Time: 07:09 PM
- */
-
 namespace App\Repositories;
 
 


### PR DESCRIPTION
When using the command, I noticed the stubs also contain the comment, which results in it being in the generated classes. Obviously not a big deal, but I thought I would remove it.