### PR TITLE
add namespace for model when it didn't exist

### DIFF
--- a/src/Commands/MakeRepositoryCommand.php
+++ b/src/Commands/MakeRepositoryCommand.php
@@ -100,7 +100,7 @@ class MakeRepositoryCommand extends GeneratorCommand
         if ($this->option('imp')) {
             $this->createImp();
         }
-        if ($this->modelName && ! class_exists($this->modelName)) {
+        if ($this->modelName && !class_exists(strpos($this->modelName, 'App\Models') === 0 ? $this->modelName : 'App\Models\\' . $this->modelName)) {
             $this->createModel();
         }
 


### PR DESCRIPTION
When the model existed, questions were asked again to build the model.